### PR TITLE
Fix parallel make (e.g. make -j2) failure

### DIFF
--- a/CuteMarkEd.pro
+++ b/CuteMarkEd.pro
@@ -6,7 +6,7 @@
 
 TEMPLATE = subdirs
 
-CONFIG += c++11
+CONFIG += c++11 ordered
 
 SUBDIRS = \
     3rdparty \
@@ -17,4 +17,3 @@ SUBDIRS = \
     test
 
 app.depends = 3rdparty libs app-static
-

--- a/CuteMarkEd.pro
+++ b/CuteMarkEd.pro
@@ -6,7 +6,7 @@
 
 TEMPLATE = subdirs
 
-CONFIG += c++11 ordered
+CONFIG += c++11
 
 SUBDIRS = \
     3rdparty \
@@ -17,3 +17,6 @@ SUBDIRS = \
     test
 
 app.depends = 3rdparty libs app-static
+libs.depends = 3rdparty
+app-static.depends = 3rdparty
+test.depends = 3rdparty libs app-static

--- a/CuteMarkEd.pro
+++ b/CuteMarkEd.pro
@@ -16,7 +16,6 @@ SUBDIRS = \
     fontawesomeicon \
     test
 
-app.depends = 3rdparty libs app-static
+app.depends = libs app-static
 libs.depends = 3rdparty
-app-static.depends = 3rdparty
-test.depends = 3rdparty libs app-static
+test.depends = libs app-static


### PR DESCRIPTION
Parallel make may fail because dependencies among sub projects are not fully specified in the top level .pro file . Thus when building these targets will be built in arbitrary order.