### PR TITLE
Inline $...$ equations support

### DIFF
--- a/app-static/template/htmltemplate.cpp
+++ b/app-static/template/htmltemplate.cpp
@@ -99,7 +99,7 @@ QString HtmlTemplate::buildHtmlHeader(RenderOptions options) const
 
         // Add MathJax support for inline LaTeX Math
         if (options.testFlag(Template::MathInlineSupport)) {
-            header += "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>";
+            header += "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}});</script>";
         }
 
         header += "<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>\n";

--- a/app-static/template/htmltemplate.cpp
+++ b/app-static/template/htmltemplate.cpp
@@ -96,7 +96,12 @@ QString HtmlTemplate::buildHtmlHeader(RenderOptions options) const
 
     // add MathJax.js script to HTML header
     if (options.testFlag(Template::MathSupport)) {
-        header += "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>";
+
+        // Add MathJax support for inline LaTeX Math
+        if (options.testFlag(Template::MathInlineSupport)) {
+            header += "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>";
+        }
+
         header += "<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>\n";
     }
 

--- a/app-static/template/htmltemplate.cpp
+++ b/app-static/template/htmltemplate.cpp
@@ -96,6 +96,7 @@ QString HtmlTemplate::buildHtmlHeader(RenderOptions options) const
 
     // add MathJax.js script to HTML header
     if (options.testFlag(Template::MathSupport)) {
+        header += "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>";
         header += "<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>\n";
     }
 

--- a/app-static/template/template.h
+++ b/app-static/template/template.h
@@ -41,7 +41,8 @@ public:
         ScrollbarSynchronization = 0x00000001,
         MathSupport              = 0x00000002,
         CodeHighlighting         = 0x00000004,
-        DiagramSupport           = 0x00000008
+        DiagramSupport           = 0x00000008,
+        MathInlineSupport        = 0x00000010
     };
     Q_DECLARE_FLAGS(RenderOptions, RenderOption)
 

--- a/app/htmlpreviewgenerator.cpp
+++ b/app/htmlpreviewgenerator.cpp
@@ -256,6 +256,11 @@ Template::RenderOptions HtmlPreviewGenerator::renderOptions() const
         renderOptionFlags |= Template::MathSupport;
     }
 
+    // inline math support
+    if (options->isMathInlineSupportEnabled()) {
+        renderOptionFlags |= Template::MathInlineSupport;
+    }
+
     // diagram support
     if (options->isDiagramSupportEnabled()) {
         renderOptionFlags |= Template::DiagramSupport;

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -46,6 +46,7 @@ static const char* SMARTYPANTS_ENABLED = "extensions/smartyPants";
 static const char* FOOTNOTES_ENABLED = "extensions/footnotes";
 static const char* SUPERSCRIPT_ENABLED = "extensions/superscript";
 static const char* MATHSUPPORT_ENABLED = "mathsupport/enabled";
+static const char* MATHINLINESUPPORT_ENABLED = "mathinlinesupport/enabled";
 static const char* CODEHIGHLIGHT_ENABLED = "codehighlighting/enabled";
 static const char* SHOWSPECIALCHARACTERS_ENABLED = "specialchars/enabled";
 static const char* WORDWRAP_ENABLED = "wordwrap/enabled";
@@ -67,6 +68,7 @@ Options::Options(QObject *parent) :
     m_footnotesEnabled(true),
     m_superscriptEnabled(true),
     m_mathSupportEnabled(false),
+    m_mathInlineSupportEnabled(false), //**
     m_codeHighlightingEnabled(false),
     m_showSpecialCharactersEnabled(false),
     m_wordWrapEnabled(true),
@@ -319,6 +321,16 @@ void Options::setMathSupportEnabled(bool enabled)
     m_mathSupportEnabled = enabled;
 }
 
+bool Options::isMathInlineSupportEnabled() const
+{
+    return m_mathInlineSupportEnabled;
+}
+
+void Options::setMathInlineSupportEnabled(bool enabled)
+{
+    m_mathInlineSupportEnabled = enabled;
+}
+
 bool Options::isCodeHighlightingEnabled() const
 {
     return m_codeHighlightingEnabled;
@@ -438,6 +450,7 @@ void Options::readSettings()
     m_sansSerifFontFamily = settings.value(PREVIEW_SANSSERIF_FONT, globalWebSettings->fontFamily(QWebSettings::SansSerifFont)).toString();
     m_defaultFontSize = settings.value(PREVIEW_DEFAULT_FONT_SIZE, globalWebSettings->fontSize(QWebSettings::DefaultFontSize)).toInt();
     m_defaultFixedFontSize = settings.value(PREVIEW_DEFAULT_FIXED_FONT_SIZE, globalWebSettings->fontSize(QWebSettings::DefaultFixedFontSize)).toInt();
+    m_mathInlineSupportEnabled = settings.value(MATHINLINESUPPORT_ENABLED, false).toBool();
 
     // proxy settings
     m_proxyMode = (Options::ProxyMode)settings.value(PROXY_MODE, 0).toInt();
@@ -497,6 +510,7 @@ void Options::writeSettings()
     settings.setValue(PREVIEW_SANSSERIF_FONT, m_sansSerifFontFamily);
     settings.setValue(PREVIEW_DEFAULT_FONT_SIZE, m_defaultFontSize);
     settings.setValue(PREVIEW_DEFAULT_FIXED_FONT_SIZE, m_defaultFixedFontSize);
+    settings.setValue(MATHINLINESUPPORT_ENABLED, m_mathInlineSupportEnabled);
 
     // proxy settings
     settings.setValue(PROXY_MODE, m_proxyMode);

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -68,7 +68,7 @@ Options::Options(QObject *parent) :
     m_footnotesEnabled(true),
     m_superscriptEnabled(true),
     m_mathSupportEnabled(false),
-    m_mathInlineSupportEnabled(false), //**
+    m_mathInlineSupportEnabled(false),
     m_codeHighlightingEnabled(false),
     m_showSpecialCharactersEnabled(false),
     m_wordWrapEnabled(true),

--- a/app/options.h
+++ b/app/options.h
@@ -109,6 +109,9 @@ public:
     bool isMathSupportEnabled() const;
     void setMathSupportEnabled(bool enabled);
 
+    bool isMathInlineSupportEnabled() const;
+    void setMathInlineSupportEnabled(bool enabled);
+
     bool isCodeHighlightingEnabled() const;
     void setCodeHighlightingEnabled(bool enabled);
 
@@ -161,6 +164,7 @@ private:
     bool m_footnotesEnabled;
     bool m_superscriptEnabled;
     bool m_mathSupportEnabled;
+    bool m_mathInlineSupportEnabled;//**
     bool m_codeHighlightingEnabled;
     bool m_showSpecialCharactersEnabled;
     bool m_wordWrapEnabled;

--- a/app/options.h
+++ b/app/options.h
@@ -164,7 +164,7 @@ private:
     bool m_footnotesEnabled;
     bool m_superscriptEnabled;
     bool m_mathSupportEnabled;
-    bool m_mathInlineSupportEnabled;//**
+    bool m_mathInlineSupportEnabled;
     bool m_codeHighlightingEnabled;
     bool m_showSpecialCharactersEnabled;
     bool m_wordWrapEnabled;

--- a/app/optionsdialog.cpp
+++ b/app/optionsdialog.cpp
@@ -286,6 +286,7 @@ void OptionsDialog::readState()
     ui->fontComboBox->setCurrentFont(font);
     ui->sizeComboBox->setCurrentText(QString().setNum(font.pointSize()));
     ui->tabWidthSpinBox->setValue(options->tabWidth());
+    ui->mathInlineCheckBox->setChecked(options->isMathInlineSupportEnabled()); //**
 
     // html preview settings
     ui->standardFontComboBox->setCurrentFont(options->standardFont());
@@ -330,6 +331,7 @@ void OptionsDialog::saveState()
     font.setPointSize(ui->sizeComboBox->currentText().toInt());
     options->setEditorFont(font);
     options->setTabWidth(ui->tabWidthSpinBox->value());
+    options->setMathInlineSupportEnabled(ui->mathInlineCheckBox->isChecked());
 
     // html preview settings
     options->setStandardFont(ui->standardFontComboBox->currentFont());

--- a/app/optionsdialog.cpp
+++ b/app/optionsdialog.cpp
@@ -286,7 +286,6 @@ void OptionsDialog::readState()
     ui->fontComboBox->setCurrentFont(font);
     ui->sizeComboBox->setCurrentText(QString().setNum(font.pointSize()));
     ui->tabWidthSpinBox->setValue(options->tabWidth());
-    ui->mathInlineCheckBox->setChecked(options->isMathInlineSupportEnabled()); //**
 
     // html preview settings
     ui->standardFontComboBox->setCurrentFont(options->standardFont());
@@ -295,6 +294,8 @@ void OptionsDialog::readState()
     ui->sansSerifFontComboBox->setCurrentFont(options->sansSerifFont());
     ui->fixedFontComboBox->setCurrentFont(options->fixedFont());
     ui->defaultFixedSizeComboBox->setCurrentText(QString().setNum(options->defaultFixedFontSize()));
+    ui->mathInlineCheckBox->setChecked(options->isMathInlineSupportEnabled());
+    ui->mathSupportCheckBox->setChecked(options->isMathSupportEnabled());
 
     // proxy settings
     switch (options->proxyMode()) {
@@ -332,6 +333,7 @@ void OptionsDialog::saveState()
     options->setEditorFont(font);
     options->setTabWidth(ui->tabWidthSpinBox->value());
     options->setMathInlineSupportEnabled(ui->mathInlineCheckBox->isChecked());
+    options->setMathSupportEnabled(ui->mathSupportCheckBox->isChecked());
 
     // html preview settings
     options->setStandardFont(ui->standardFontComboBox->currentFont());

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -221,6 +221,9 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QFontComboBox" name="sansSerifFontComboBox"/>
+          </item>
           <item row="1" column="1">
            <widget class="QFontComboBox" name="serifFontComboBox"/>
           </item>
@@ -234,8 +237,8 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QFontComboBox" name="sansSerifFontComboBox"/>
+          <item row="3" column="1">
+           <widget class="QFontComboBox" name="fixedFontComboBox"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="fixedFontLabel">
@@ -247,8 +250,8 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QFontComboBox" name="fixedFontComboBox"/>
+          <item row="3" column="3">
+           <widget class="QComboBox" name="defaultFixedSizeComboBox"/>
           </item>
           <item row="3" column="2">
            <widget class="QLabel" name="defaultFixedSizeLabel">
@@ -257,8 +260,34 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
-           <widget class="QComboBox" name="defaultFixedSizeComboBox"/>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="mathGroupBox">
+         <property name="title">
+          <string>Math Support</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QCheckBox" name="mathInlineCheckBox">
+            <property name="text">
+             <string>Support for LaTeX inline formula</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="mathSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>364</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -268,26 +268,20 @@
          <property name="title">
           <string>Math Support</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <layout class="QVBoxLayout" name="verticalLayout_9">
           <item>
-           <widget class="QCheckBox" name="mathInlineCheckBox">
+           <widget class="QCheckBox" name="mathSupportCheckBox">
             <property name="text">
-             <string>Support for LaTeX inline formula</string>
+             <string>Enable Math Suport</string>
             </property>
            </widget>
           </item>
           <item>
-           <spacer name="mathSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+           <widget class="QCheckBox" name="mathInlineCheckBox">
+            <property name="text">
+             <string>Enable LaTeX syntax for inline Math</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>364</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
I'm very used to write on latex inline formulas with `$...$`, but I could't get this when using CuteMarkEd, so, regarding you use Mathjax, I've made a change to use this [notation](http://docs.mathjax.org/en/latest/start.html#tex-and-latex-input), it has been enable on Mathjax configuration.
![cutemarked](https://cloud.githubusercontent.com/assets/667239/10007386/01cf8466-60c5-11e5-91f3-f636b0e1c2e1.png)
It would be great to add this support on options dialog (because people use USD$ signs should escape `\$` sign), but I don't know the c++ and Qt tools as sufficient as add them by myself
