### PR TITLE
Check if map of custom shortcuts contains empty values before applying them

### DIFF
--- a/app/options.cpp
+++ b/app/options.cpp
@@ -233,7 +233,8 @@ void Options::addCustomShortcut(const QString &actionName, const QKeySequence &k
 
 bool Options::hasCustomShortcut(const QString &actionName) const
 {
-    return m_customShortcuts.contains(actionName);
+    if(m_customShortcuts.contains(actionName))
+        return !m_customShortcuts.value(actionName).isEmpty();
 }
 
 QKeySequence Options::customShortcut(const QString &actionName) const


### PR DESCRIPTION
Default shortcut did not always work because map with custom shortcuts might contain entries with empty values. Not sure why there are entries without value at all. But this fixes the problem for me.