### PR TITLE
New option at the extras menu to show all input lines at the source window at one size (fixes #205)

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -144,7 +144,6 @@ void MainWindow::initializeApp()
     ui->actionCodeHighlighting->setChecked(options->isCodeHighlightingEnabled());
     ui->actionShowSpecialCharacters->setChecked(options->isShowSpecialCharactersEnabled());
     ui->actionWordWrap->setChecked(options->isWordWrapEnabled());
-    ui->actionSourceAtOneSize->setChecked(options->isSourceAtOneSizeEnabled());
     ui->actionCheckSpelling->setChecked(options->isSpellingCheckEnabled());
     ui->plainTextEdit->setSpellingCheckEnabled(options->isSpellingCheckEnabled());
     ui->actionYamlHeaderSupport->setChecked(options->isYamlHeaderSupportEnabled());
@@ -479,11 +478,7 @@ void MainWindow::lastUsedStyle()
 void MainWindow::styleDefault()
 {
     generator->setCodeHighlightingStyle("default");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("default"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/markdown.css"));
 
     styleLabel->setText(ui->actionDefault->text());
@@ -493,13 +488,7 @@ void MainWindow::styleDefault()
 void MainWindow::styleGithub()
 {
     generator->setCodeHighlightingStyle("github");
-
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
-    }
-
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("default"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/github.css"));
 
     styleLabel->setText(ui->actionGithub->text());
@@ -509,11 +498,7 @@ void MainWindow::styleGithub()
 void MainWindow::styleSolarizedLight()
 {
     generator->setCodeHighlightingStyle("solarized_light");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-light.txt");
-    } else {
-       ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-light+.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("solarized-light"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/solarized-light.css"));
 
     styleLabel->setText(ui->actionSolarizedLight->text());
@@ -523,11 +508,7 @@ void MainWindow::styleSolarizedLight()
 void MainWindow::styleSolarizedDark()
 {
     generator->setCodeHighlightingStyle("solarized_dark");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-dark.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-dark+.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("solarized-dark"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/solarized-dark.css"));
 
     styleLabel->setText(ui->actionSolarizedDark->text());
@@ -537,11 +518,7 @@ void MainWindow::styleSolarizedDark()
 void MainWindow::styleClearness()
 {
     generator->setCodeHighlightingStyle("default");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("default"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/clearness.css"));
 
     styleLabel->setText(ui->actionClearness->text());
@@ -551,11 +528,7 @@ void MainWindow::styleClearness()
 void MainWindow::styleClearnessDark()
 {
     generator->setCodeHighlightingStyle("default");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/clearness-dark.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/clearness-dark+.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("clearness-dark"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/clearness-dark.css"));
 
     styleLabel->setText(ui->actionClearnessDark->text());
@@ -565,11 +538,7 @@ void MainWindow::styleClearnessDark()
 void MainWindow::styleBywordDark()
 {
     generator->setCodeHighlightingStyle("default");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/byword-dark.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/byword-dark+.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("byword-dark"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/byword-dark.css"));
 
     styleLabel->setText(ui->actionBywordDark->text());
@@ -581,11 +550,7 @@ void MainWindow::styleCustomStyle()
     QAction *action = qobject_cast<QAction*>(sender());
 
     generator->setCodeHighlightingStyle("default");
-    if(options->isSourceAtOneSizeEnabled()) {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
-    } else {
-        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
-    }
+    ui->plainTextEdit->loadStyleFromStylesheet(stylePath("default"));
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl::fromLocalFile(action->data().toString()));
 
     styleLabel->setText(action->text());
@@ -628,13 +593,6 @@ void MainWindow::extrasWordWrap(bool checked)
     options->setWordWrapEnabled(checked);
     ui->plainTextEdit->setLineWrapMode(checked ? MarkdownEditor::WidgetWidth : MarkdownEditor::NoWrap);
 }
-
-void MainWindow::extrasSourceAtOneSize(bool checked)
-{
-    options->setSourceAtOneSizeEnabled(checked);
-    lastUsedStyle();
-}
-
 
 void MainWindow::extensionsAutolink(bool checked)
 {
@@ -961,6 +919,11 @@ void MainWindow::markdownConverterChanged()
     }
 }
 
+void MainWindow::editorFontChanged(QFont font)
+{
+    lastUsedStyle();
+}
+
 void MainWindow::setupUi()
 {
     htmlPreviewController = new HtmlPreviewController(ui->webView, this);
@@ -991,6 +954,8 @@ void MainWindow::setupUi()
             this, SLOT(proxyConfigurationChanged()));
     connect(options, SIGNAL(markdownConverterChanged()),
             this, SLOT(markdownConverterChanged()));
+    connect(options, SIGNAL(editorFontChanged(QFont)),
+            this, SLOT(editorFontChanged(QFont)));
 
     readSettings();
     setupCustomShortcuts();
@@ -1321,4 +1286,10 @@ void MainWindow::writeSettings()
     QSettings settings;
     settings.setValue("mainWindow/geometry", saveGeometry());
     settings.setValue("mainWindow/windowState", saveState());
+}
+
+QString MainWindow::stylePath(const QString &styleName)
+{
+    QString suffix = options->isSourceAtSingleSizeEnabled() ? "" : "+";
+    return QString(":/theme/%1%2.txt").arg(styleName).arg(suffix);
 }

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -144,6 +144,7 @@ void MainWindow::initializeApp()
     ui->actionCodeHighlighting->setChecked(options->isCodeHighlightingEnabled());
     ui->actionShowSpecialCharacters->setChecked(options->isShowSpecialCharactersEnabled());
     ui->actionWordWrap->setChecked(options->isWordWrapEnabled());
+    ui->actionSourceAtOneSize->setChecked(options->isSourceAtOneSizeEnabled());
     ui->actionCheckSpelling->setChecked(options->isSpellingCheckEnabled());
     ui->plainTextEdit->setSpellingCheckEnabled(options->isSpellingCheckEnabled());
     ui->actionYamlHeaderSupport->setChecked(options->isYamlHeaderSupportEnabled());
@@ -478,8 +479,11 @@ void MainWindow::lastUsedStyle()
 void MainWindow::styleDefault()
 {
     generator->setCodeHighlightingStyle("default");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/markdown.css"));
 
     styleLabel->setText(ui->actionDefault->text());
@@ -490,7 +494,12 @@ void MainWindow::styleGithub()
 {
     generator->setCodeHighlightingStyle("github");
 
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    }
+
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/github.css"));
 
     styleLabel->setText(ui->actionGithub->text());
@@ -500,8 +509,11 @@ void MainWindow::styleGithub()
 void MainWindow::styleSolarizedLight()
 {
     generator->setCodeHighlightingStyle("solarized_light");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-light+.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-light.txt");
+    } else {
+       ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-light+.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/solarized-light.css"));
 
     styleLabel->setText(ui->actionSolarizedLight->text());
@@ -511,8 +523,11 @@ void MainWindow::styleSolarizedLight()
 void MainWindow::styleSolarizedDark()
 {
     generator->setCodeHighlightingStyle("solarized_dark");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-dark+.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-dark.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/solarized-dark+.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/solarized-dark.css"));
 
     styleLabel->setText(ui->actionSolarizedDark->text());
@@ -522,8 +537,11 @@ void MainWindow::styleSolarizedDark()
 void MainWindow::styleClearness()
 {
     generator->setCodeHighlightingStyle("default");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/clearness.css"));
 
     styleLabel->setText(ui->actionClearness->text());
@@ -533,8 +551,11 @@ void MainWindow::styleClearness()
 void MainWindow::styleClearnessDark()
 {
     generator->setCodeHighlightingStyle("default");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/clearness-dark+.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/clearness-dark.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/clearness-dark+.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/clearness-dark.css"));
 
     styleLabel->setText(ui->actionClearnessDark->text());
@@ -544,8 +565,11 @@ void MainWindow::styleClearnessDark()
 void MainWindow::styleBywordDark()
 {
     generator->setCodeHighlightingStyle("default");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/byword-dark.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/byword-dark.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/byword-dark+.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl("qrc:/css/byword-dark.css"));
 
     styleLabel->setText(ui->actionBywordDark->text());
@@ -557,8 +581,11 @@ void MainWindow::styleCustomStyle()
     QAction *action = qobject_cast<QAction*>(sender());
 
     generator->setCodeHighlightingStyle("default");
-
-    ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    if(options->isSourceAtOneSizeEnabled()) {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default-.txt");
+    } else {
+        ui->plainTextEdit->loadStyleFromStylesheet(":/theme/default.txt");
+    }
     ui->webView->page()->settings()->setUserStyleSheetUrl(QUrl::fromLocalFile(action->data().toString()));
 
     styleLabel->setText(action->text());
@@ -601,6 +628,13 @@ void MainWindow::extrasWordWrap(bool checked)
     options->setWordWrapEnabled(checked);
     ui->plainTextEdit->setLineWrapMode(checked ? MarkdownEditor::WidgetWidth : MarkdownEditor::NoWrap);
 }
+
+void MainWindow::extrasSourceAtOneSize(bool checked)
+{
+    options->setSourceAtOneSizeEnabled(checked);
+    lastUsedStyle();
+}
+
 
 void MainWindow::extensionsAutolink(bool checked)
 {
@@ -1288,4 +1322,3 @@ void MainWindow::writeSettings()
     settings.setValue("mainWindow/geometry", saveGeometry());
     settings.setValue("mainWindow/windowState", saveState());
 }
-

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -919,11 +919,6 @@ void MainWindow::markdownConverterChanged()
     }
 }
 
-void MainWindow::editorFontChanged()
-{
-    lastUsedStyle();
-}
-
 void MainWindow::setupUi()
 {
     htmlPreviewController = new HtmlPreviewController(ui->webView, this);
@@ -955,7 +950,7 @@ void MainWindow::setupUi()
     connect(options, SIGNAL(markdownConverterChanged()),
             this, SLOT(markdownConverterChanged()));
     connect(options, SIGNAL(editorFontChanged(QFont)),
-            this, SLOT(editorFontChanged()));
+            this, SLOT(lastUsedStyle()));
 
     readSettings();
     setupCustomShortcuts();

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -919,7 +919,7 @@ void MainWindow::markdownConverterChanged()
     }
 }
 
-void MainWindow::editorFontChanged(QFont font)
+void MainWindow::editorFontChanged()
 {
     lastUsedStyle();
 }
@@ -955,7 +955,7 @@ void MainWindow::setupUi()
     connect(options, SIGNAL(markdownConverterChanged()),
             this, SLOT(markdownConverterChanged()));
     connect(options, SIGNAL(editorFontChanged(QFont)),
-            this, SLOT(editorFontChanged(QFont)));
+            this, SLOT(editorFontChanged()));
 
     readSettings();
     setupCustomShortcuts();

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -98,7 +98,6 @@ private slots:
     void extrasShowSpecialCharacters(bool checked);
     void extrasYamlHeaderSupport(bool checked);
     void extrasWordWrap(bool checked);
-    void extrasSourceAtOneSize(bool checked);
     void extensionsAutolink(bool checked);
     void extensionsStrikethrough(bool checked);
     void extensionsAlphabeticLists(bool checked);
@@ -128,6 +127,7 @@ private slots:
     bool load(const QString &fileName);
     void proxyConfigurationChanged();
     void markdownConverterChanged();
+    void editorFontChanged(QFont);
 
 private:
     void setupUi();
@@ -147,6 +147,7 @@ private:
     void loadCustomStyles();
     void readSettings();
     void writeSettings();
+    QString stylePath(const QString &styleName);
 
 private:
     Ui::MainWindow *ui;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -98,6 +98,7 @@ private slots:
     void extrasShowSpecialCharacters(bool checked);
     void extrasYamlHeaderSupport(bool checked);
     void extrasWordWrap(bool checked);
+    void extrasSourceAtOneSize(bool checked);
     void extensionsAutolink(bool checked);
     void extensionsStrikethrough(bool checked);
     void extensionsAlphabeticLists(bool checked);

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -127,7 +127,7 @@ private slots:
     bool load(const QString &fileName);
     void proxyConfigurationChanged();
     void markdownConverterChanged();
-    void editorFontChanged(QFont);
+    void editorFontChanged();
 
 private:
     void setupUi();

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -127,7 +127,6 @@ private slots:
     bool load(const QString &fileName);
     void proxyConfigurationChanged();
     void markdownConverterChanged();
-    void editorFontChanged();
 
 private:
     void setupUi();

--- a/app/mainwindow.ui
+++ b/app/mainwindow.ui
@@ -289,7 +289,6 @@
     <addaction name="actionCodeHighlighting"/>
     <addaction name="actionShowSpecialCharacters"/>
     <addaction name="actionWordWrap"/>
-    <addaction name="actionSourceAtOneSize"/>
     <addaction name="menuMarkdown_Extensions"/>
     <addaction name="separator"/>
     <addaction name="actionCheckSpelling"/>
@@ -815,17 +814,6 @@
    </property>
    <property name="text">
     <string>&amp;Diagram Support</string>
-   </property>
-  </action>
-  <action name="actionSourceAtOneSize">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Source at one size </string>
-   </property>
-   <property name="toolTip">
-    <string>Show source at one size</string>
    </property>
   </action>
  </widget>
@@ -1823,22 +1811,6 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>actionSourceAtOneSize</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>extrasSourceAtOneSize(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>424</x>
-     <y>266</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <slots>
   <slot>editInsertTable()</slot>
@@ -1849,7 +1821,6 @@
   <slot>extensionsSuperscript(bool)</slot>
   <slot>extrasShowSpecialCharacters(bool)</slot>
   <slot>extrasWordWrap(bool)</slot>
-  <slot>extrasSourceAtOneSize(bool)</slot>
   <slot>extrasYamlHeaderSupport(bool)</slot>
  </slots>
 </ui>

--- a/app/mainwindow.ui
+++ b/app/mainwindow.ui
@@ -167,7 +167,7 @@
      <x>0</x>
      <y>0</y>
      <width>850</width>
-     <height>21</height>
+     <height>18</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -289,6 +289,7 @@
     <addaction name="actionCodeHighlighting"/>
     <addaction name="actionShowSpecialCharacters"/>
     <addaction name="actionWordWrap"/>
+    <addaction name="actionSourceAtOneSize"/>
     <addaction name="menuMarkdown_Extensions"/>
     <addaction name="separator"/>
     <addaction name="actionCheckSpelling"/>
@@ -814,6 +815,17 @@
    </property>
    <property name="text">
     <string>&amp;Diagram Support</string>
+   </property>
+  </action>
+  <action name="actionSourceAtOneSize">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Source at one size </string>
+   </property>
+   <property name="toolTip">
+    <string>Show source at one size</string>
    </property>
   </action>
  </widget>
@@ -1811,6 +1823,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionSourceAtOneSize</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>extrasSourceAtOneSize(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>424</x>
+     <y>266</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>editInsertTable()</slot>
@@ -1821,6 +1849,7 @@
   <slot>extensionsSuperscript(bool)</slot>
   <slot>extrasShowSpecialCharacters(bool)</slot>
   <slot>extrasWordWrap(bool)</slot>
+  <slot>extrasSourceAtOneSize(bool)</slot>
   <slot>extrasYamlHeaderSupport(bool)</slot>
  </slots>
 </ui>

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -50,7 +50,7 @@ static const char* MATHINLINESUPPORT_ENABLED = "mathinlinesupport/enabled";
 static const char* CODEHIGHLIGHT_ENABLED = "codehighlighting/enabled";
 static const char* SHOWSPECIALCHARACTERS_ENABLED = "specialchars/enabled";
 static const char* WORDWRAP_ENABLED = "wordwrap/enabled";
-static const char* SOURCEATONESIZE_ENABLED = "sourceatonesize/enabled";
+static const char* SOURCEATSINGLESIZE_ENABLED = "sourceatsinglesize/enabled";
 static const char* SPELLINGCHECK_ENABLED = "spelling/enabled";
 static const char* DICTIONARY_LANGUAGE = "spelling/language";
 static const char* YAMLHEADERSUPPORT_ENABLED = "yamlheadersupport/enabled";
@@ -74,7 +74,7 @@ Options::Options(QObject *parent) :
     m_codeHighlightingEnabled(false),
     m_showSpecialCharactersEnabled(false),
     m_wordWrapEnabled(true),
-    m_sourceAtOneSizeEnabled(true),
+    m_sourceAtSingleSizeEnabled(true),
     m_spellingCheckEnabled(true),
     m_diagramSupportEnabled(false),
     m_markdownConverter(DiscountMarkdownConverter),
@@ -94,6 +94,7 @@ void Options::apply()
 
     emit proxyConfigurationChanged();
     emit markdownConverterChanged();
+    emit editorFontChanged(editorFont());
 }
 
 QFont Options::editorFont() const
@@ -364,14 +365,14 @@ void Options::setWordWrapEnabled(bool enabled)
     m_wordWrapEnabled = enabled;
 }
 
-bool Options::isSourceAtOneSizeEnabled() const
+bool Options::isSourceAtSingleSizeEnabled() const
 {
-    return m_sourceAtOneSizeEnabled;
+    return m_sourceAtSingleSizeEnabled;
 }
 
-void Options::setSourceAtOneSizeEnabled(bool enabled)
+void Options::setSourceAtSingleSizeEnabled(bool enabled)
 {
-    m_sourceAtOneSizeEnabled = enabled;
+    m_sourceAtSingleSizeEnabled = enabled;
 }
 
 bool Options::isSpellingCheckEnabled() const
@@ -493,15 +494,13 @@ void Options::readSettings()
     m_codeHighlightingEnabled = settings.value(CODEHIGHLIGHT_ENABLED, false).toBool();
     m_showSpecialCharactersEnabled = settings.value(SHOWSPECIALCHARACTERS_ENABLED, false).toBool();
     m_wordWrapEnabled = settings.value(WORDWRAP_ENABLED, true).toBool();
-    m_sourceAtOneSizeEnabled = settings.value(SOURCEATONESIZE_ENABLED, true).toBool();
+    m_sourceAtSingleSizeEnabled = settings.value(SOURCEATSINGLESIZE_ENABLED, true).toBool();
     m_yamlHeaderSupportEnabled = settings.value(YAMLHEADERSUPPORT_ENABLED, false).toBool();
     m_diagramSupportEnabled = settings.value(DIAGRAMSUPPORT_ENABLED, false).toBool();
 
     // spelling check settings
     m_spellingCheckEnabled = settings.value(SPELLINGCHECK_ENABLED, true).toBool();
     m_dictionaryLanguage = settings.value(DICTIONARY_LANGUAGE, "en_US").toString();
-
-    //Source viewer settings
 
     apply();
 }
@@ -557,7 +556,7 @@ void Options::writeSettings()
     settings.setValue(CODEHIGHLIGHT_ENABLED, m_codeHighlightingEnabled);
     settings.setValue(SHOWSPECIALCHARACTERS_ENABLED, m_showSpecialCharactersEnabled);
     settings.setValue(WORDWRAP_ENABLED, m_wordWrapEnabled);
-    settings.setValue(SOURCEATONESIZE_ENABLED, m_sourceAtOneSizeEnabled);
+    settings.setValue(SOURCEATSINGLESIZE_ENABLED, m_sourceAtSingleSizeEnabled);
     settings.setValue(YAMLHEADERSUPPORT_ENABLED, m_yamlHeaderSupportEnabled);
     settings.setValue(DIAGRAMSUPPORT_ENABLED, m_diagramSupportEnabled);
 

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -50,10 +50,12 @@ static const char* MATHINLINESUPPORT_ENABLED = "mathinlinesupport/enabled";
 static const char* CODEHIGHLIGHT_ENABLED = "codehighlighting/enabled";
 static const char* SHOWSPECIALCHARACTERS_ENABLED = "specialchars/enabled";
 static const char* WORDWRAP_ENABLED = "wordwrap/enabled";
+static const char* SOURCEATONESIZE_ENABLED = "sourceatonesize/enabled";
 static const char* SPELLINGCHECK_ENABLED = "spelling/enabled";
 static const char* DICTIONARY_LANGUAGE = "spelling/language";
 static const char* YAMLHEADERSUPPORT_ENABLED = "yamlheadersupport/enabled";
 static const char* DIAGRAMSUPPORT_ENABLED = "diagramsupport/enabled";
+
 
 Options::Options(QObject *parent) :
     QObject(parent),
@@ -72,6 +74,7 @@ Options::Options(QObject *parent) :
     m_codeHighlightingEnabled(false),
     m_showSpecialCharactersEnabled(false),
     m_wordWrapEnabled(true),
+    m_sourceAtOneSizeEnabled(true),
     m_spellingCheckEnabled(true),
     m_diagramSupportEnabled(false),
     m_markdownConverter(DiscountMarkdownConverter),
@@ -361,6 +364,16 @@ void Options::setWordWrapEnabled(bool enabled)
     m_wordWrapEnabled = enabled;
 }
 
+bool Options::isSourceAtOneSizeEnabled() const
+{
+    return m_sourceAtOneSizeEnabled;
+}
+
+void Options::setSourceAtOneSizeEnabled(bool enabled)
+{
+    m_sourceAtOneSizeEnabled = enabled;
+}
+
 bool Options::isSpellingCheckEnabled() const
 {
     return m_spellingCheckEnabled;
@@ -480,12 +493,15 @@ void Options::readSettings()
     m_codeHighlightingEnabled = settings.value(CODEHIGHLIGHT_ENABLED, false).toBool();
     m_showSpecialCharactersEnabled = settings.value(SHOWSPECIALCHARACTERS_ENABLED, false).toBool();
     m_wordWrapEnabled = settings.value(WORDWRAP_ENABLED, true).toBool();
+    m_sourceAtOneSizeEnabled = settings.value(SOURCEATONESIZE_ENABLED, true).toBool();
     m_yamlHeaderSupportEnabled = settings.value(YAMLHEADERSUPPORT_ENABLED, false).toBool();
     m_diagramSupportEnabled = settings.value(DIAGRAMSUPPORT_ENABLED, false).toBool();
 
     // spelling check settings
     m_spellingCheckEnabled = settings.value(SPELLINGCHECK_ENABLED, true).toBool();
     m_dictionaryLanguage = settings.value(DICTIONARY_LANGUAGE, "en_US").toString();
+
+    //Source viewer settings
 
     apply();
 }
@@ -541,6 +557,7 @@ void Options::writeSettings()
     settings.setValue(CODEHIGHLIGHT_ENABLED, m_codeHighlightingEnabled);
     settings.setValue(SHOWSPECIALCHARACTERS_ENABLED, m_showSpecialCharactersEnabled);
     settings.setValue(WORDWRAP_ENABLED, m_wordWrapEnabled);
+    settings.setValue(SOURCEATONESIZE_ENABLED, m_sourceAtOneSizeEnabled);
     settings.setValue(YAMLHEADERSUPPORT_ENABLED, m_yamlHeaderSupportEnabled);
     settings.setValue(DIAGRAMSUPPORT_ENABLED, m_diagramSupportEnabled);
 

--- a/app/options.h
+++ b/app/options.h
@@ -121,6 +121,9 @@ public:
     bool isWordWrapEnabled() const;
     void setWordWrapEnabled(bool enabled);
 
+    bool isSourceAtOneSizeEnabled() const;
+    void setSourceAtOneSizeEnabled(bool enabled);
+
     bool isSpellingCheckEnabled() const;
     void setSpellingCheckEnabled(bool enabled);
 
@@ -168,6 +171,7 @@ private:
     bool m_codeHighlightingEnabled;
     bool m_showSpecialCharactersEnabled;
     bool m_wordWrapEnabled;
+    bool m_sourceAtOneSizeEnabled;
     bool m_spellingCheckEnabled;
     bool m_yamlHeaderSupportEnabled;
     bool m_diagramSupportEnabled;

--- a/app/options.h
+++ b/app/options.h
@@ -121,8 +121,8 @@ public:
     bool isWordWrapEnabled() const;
     void setWordWrapEnabled(bool enabled);
 
-    bool isSourceAtOneSizeEnabled() const;
-    void setSourceAtOneSizeEnabled(bool enabled);
+    bool isSourceAtSingleSizeEnabled() const;
+    void setSourceAtSingleSizeEnabled(bool enabled);
 
     bool isSpellingCheckEnabled() const;
     void setSpellingCheckEnabled(bool enabled);
@@ -171,7 +171,7 @@ private:
     bool m_codeHighlightingEnabled;
     bool m_showSpecialCharactersEnabled;
     bool m_wordWrapEnabled;
-    bool m_sourceAtOneSizeEnabled;
+    bool m_sourceAtSingleSizeEnabled;
     bool m_spellingCheckEnabled;
     bool m_yamlHeaderSupportEnabled;
     bool m_diagramSupportEnabled;

--- a/app/optionsdialog.cpp
+++ b/app/optionsdialog.cpp
@@ -285,6 +285,7 @@ void OptionsDialog::readState()
     QFont font = options->editorFont();
     ui->fontComboBox->setCurrentFont(font);
     ui->sizeComboBox->setCurrentText(QString().setNum(font.pointSize()));
+    ui->sourceSingleSizedCheckBox->setChecked(options->isSourceAtSingleSizeEnabled());
     ui->tabWidthSpinBox->setValue(options->tabWidth());
 
     // html preview settings
@@ -331,6 +332,7 @@ void OptionsDialog::saveState()
     QFont font = ui->fontComboBox->currentFont();
     font.setPointSize(ui->sizeComboBox->currentText().toInt());
     options->setEditorFont(font);
+    options->setSourceAtSingleSizeEnabled(ui->sourceSingleSizedCheckBox->isChecked());
     options->setTabWidth(ui->tabWidthSpinBox->value());
     options->setMathInlineSupportEnabled(ui->mathInlineCheckBox->isChecked());
     options->setMathSupportEnabled(ui->mathSupportCheckBox->isChecked());

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -117,7 +117,7 @@
           <item row="1" column="0">
            <widget class="QCheckBox" name="sourceSingleSizedCheckBox">
             <property name="text">
-             <string>Source at Single Size</string>
+             <string>Markdown Source at Single Size</string>
             </property>
            </widget>
           </item>

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -87,21 +87,11 @@
          <property name="title">
           <string>Font</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="familyLabel">
-            <property name="text">
-             <string>&amp;Family:</string>
-            </property>
-            <property name="buddy">
-             <cstring>fontComboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="1">
            <widget class="QFontComboBox" name="fontComboBox"/>
           </item>
-          <item>
+          <item row="0" column="2">
            <widget class="QLabel" name="sizeLabel">
             <property name="text">
              <string>Si&amp;ze:</string>
@@ -111,8 +101,25 @@
             </property>
            </widget>
           </item>
-          <item>
+          <item row="0" column="3">
            <widget class="QComboBox" name="sizeComboBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="familyLabel">
+            <property name="text">
+             <string>&amp;Family:</string>
+            </property>
+            <property name="buddy">
+             <cstring>fontComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="sourceSingleSizedCheckBox">
+            <property name="text">
+             <string>Source at Single Size</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/app/resources.qrc
+++ b/app/resources.qrc
@@ -14,9 +14,11 @@
         <file alias="solarized-light.txt">themes/solarized-light.txt</file>
         <file alias="solarized-light+.txt">themes/solarized-light+.txt</file>
         <file alias="default.txt">themes/default.txt</file>
+        <file alias="default-.txt">themes/default-.txt</file>
         <file alias="clearness-dark+.txt">themes/clearness-dark+.txt</file>
         <file alias="clearness-dark.txt">themes/clearness-dark.txt</file>
         <file alias="byword-dark.txt">themes/byword-dark.txt</file>
+        <file alias="byword-dark+.txt">themes/byword-dark+.txt</file>
     </qresource>
     <qresource prefix="/">
         <file>template.html</file>

--- a/app/resources.qrc
+++ b/app/resources.qrc
@@ -14,7 +14,7 @@
         <file alias="solarized-light.txt">themes/solarized-light.txt</file>
         <file alias="solarized-light+.txt">themes/solarized-light+.txt</file>
         <file alias="default.txt">themes/default.txt</file>
-        <file alias="default-.txt">themes/default-.txt</file>
+        <file alias="default+.txt">themes/default+.txt</file>
         <file alias="clearness-dark+.txt">themes/clearness-dark+.txt</file>
         <file alias="clearness-dark.txt">themes/clearness-dark.txt</file>
         <file alias="byword-dark.txt">themes/byword-dark.txt</file>

--- a/app/themes/byword-dark+.txt
+++ b/app/themes/byword-dark+.txt
@@ -1,0 +1,85 @@
+editor
+foreground: bebebe
+background: 1a1a1a
+caret: ffffff
+
+editor-selection
+foreground: 686868
+background: 312F31
+
+H1
+foreground: bebebe
+font-style: bold
+font-size: 24px
+
+H2
+foreground: bebebe
+font-style: bold
+font-size: 20px
+
+H3
+foreground: bebebe
+font-style: bold
+font-size: 17px
+
+H4
+foreground: bebebe
+font-style: bold
+font-size: 15px
+
+H5
+foreground: bebebe
+font-style: bold
+font-size: 13px
+
+H6
+foreground: bebebe
+font-style: bold
+font-size: 11px
+
+EMPH
+foreground: bebebe
+font-style: italic
+
+STRONG
+foreground: bebebe
+font-style: bold
+
+HRULE
+foreground: 676767
+
+LIST_BULLET
+foreground: 676767
+
+LIST_ENUMERATOR
+foreground: 676767
+
+LINK
+foreground: 676767
+
+AUTO_LINK_URL
+foreground: 676767
+
+AUTO_LINK_EMAIL
+foreground: 676767
+
+REFERENCE
+foreground: 676767
+
+IMAGE
+foreground: 676767
+
+CODE
+foreground: 676767
+
+VERBATIM
+foreground: 676767
+
+HTML
+foreground: 676767
+
+COMMENT
+foreground: 676767
+
+BLOCKQUOTE
+foreground: 676767

--- a/app/themes/default+.txt
+++ b/app/themes/default+.txt
@@ -10,26 +10,32 @@ background: ff4f92
 H1
 foreground: 6c71c4
 font-style: bold
+font-size: 24px
 
 H2
 foreground: 6c71c4
 font-style: bold
+font-size: 20px
 
 H3
 foreground: 6c71c4
 font-style: bold
+font-size: 17px
 
 H4
 foreground: 268bd2
 font-style: bold
+font-size: 15px
 
 H5
 foreground: 268bd2
 font-style: bold
+font-size: 13px
 
 H6
 foreground: 268bd2
 font-style: bold
+font-size: 11px
 
 EMPH
 foreground: cb4b16

--- a/app/themes/default-.txt
+++ b/app/themes/default-.txt
@@ -1,0 +1,79 @@
+editor
+foreground: 000000
+background: ffffff
+caret: 000000 
+
+editor-selection
+foreground: ffffff
+background: ff4f92
+
+H1
+foreground: 6c71c4
+font-style: bold
+
+H2
+foreground: 6c71c4
+font-style: bold
+
+H3
+foreground: 6c71c4
+font-style: bold
+
+H4
+foreground: 268bd2
+font-style: bold
+
+H5
+foreground: 268bd2
+font-style: bold
+
+H6
+foreground: 268bd2
+font-style: bold
+
+EMPH
+foreground: cb4b16
+font-style: italic
+
+STRONG
+foreground: dc322f
+font-style: bold
+
+HRULE
+foreground: 586e75
+
+LIST_BULLET
+foreground: 93a1a1
+
+LIST_ENUMERATOR
+foreground: 93a1a1
+
+LINK
+foreground: 4e279a
+
+AUTO_LINK_URL
+foreground: 4e279a
+
+AUTO_LINK_EMAIL
+foreground: 4e279a
+
+REFERENCE
+foreground: bc670f
+
+IMAGE
+foreground: cf009a
+
+CODE
+foreground: 008c00
+
+VERBATIM
+foreground: 008c00
+
+HTML_ENTITY
+foreground: 6c71c4
+
+COMMENT
+foreground: 93a1a1
+
+BLOCKQUOTE
+foreground: 93a1a1

--- a/app/themes/default.txt
+++ b/app/themes/default.txt
@@ -10,32 +10,26 @@ background: ff4f92
 H1
 foreground: 6c71c4
 font-style: bold
-font-size: 24px
 
 H2
 foreground: 6c71c4
 font-style: bold
-font-size: 20px
 
 H3
 foreground: 6c71c4
 font-style: bold
-font-size: 17px
 
 H4
 foreground: 268bd2
 font-style: bold
-font-size: 15px
 
 H5
 foreground: 268bd2
 font-style: bold
-font-size: 13px
 
 H6
 foreground: 268bd2
 font-style: bold
-font-size: 11px
 
 EMPH
 foreground: cb4b16


### PR DESCRIPTION
These changes add a new option to the extras menu to show all input lines at the source window at one size.  
It should fix issue #205  
There are no translations.