### PR TITLE
Fix ambiguity in French translation

### DIFF
--- a/app/translations/cutemarked_fr.ts
+++ b/app/translations/cutemarked_fr.ts
@@ -1000,12 +1000,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../optionsdialog.ui" line="123"/>
         <source>Tabs</source>
-        <translation>Onglets</translation>
+        <translation>Tabulations</translation>
     </message>
     <message>
         <location filename="../optionsdialog.ui" line="129"/>
         <source>&amp;Tab width:</source>
-        <translation>&amp;Largeur d&apos;un onglet :</translation>
+        <translation>&amp;Largeur d&apos;une tabulation :</translation>
     </message>
     <message>
         <location filename="../optionsdialog.ui" line="182"/>


### PR DESCRIPTION
“Tab” could be both « tabulation » and « onglet ». It's « tabulation » in this case.