### PR TITLE
Ensure that document is of correct type

### DIFF
--- a/app-static/converter/hoedownmarkdownconverter.cpp
+++ b/app-static/converter/hoedownmarkdownconverter.cpp
@@ -88,7 +88,7 @@ QString HoedownMarkdownConverter::renderAsHtml(MarkdownDocument *document)
     if (document) {
         HoedownMarkdownDocument *doc = dynamic_cast<HoedownMarkdownDocument*>(document);
 
-        if (doc->document()) {
+        if (doc && doc->document()) {
             hoedown_buffer *in = doc->document();
             hoedown_buffer *out = hoedown_buffer_new(64);
 

--- a/app-static/converter/revealmarkdownconverter.cpp
+++ b/app-static/converter/revealmarkdownconverter.cpp
@@ -30,8 +30,9 @@ QString RevealMarkdownConverter::renderAsHtml(MarkdownDocument *document)
 
     if (document) {
         RevealMarkdownDocument *doc = dynamic_cast<RevealMarkdownDocument*>(document);
-        if(doc)
+        if (doc) {
             html = doc->markdownText;
+        }
     }
 
     return html;

--- a/app-static/converter/revealmarkdownconverter.cpp
+++ b/app-static/converter/revealmarkdownconverter.cpp
@@ -30,7 +30,8 @@ QString RevealMarkdownConverter::renderAsHtml(MarkdownDocument *document)
 
     if (document) {
         RevealMarkdownDocument *doc = dynamic_cast<RevealMarkdownDocument*>(document);
-        html = doc->markdownText;
+        if(doc)
+            html = doc->markdownText;
     }
 
     return html;


### PR DESCRIPTION
this fixes #260 by ensuring that reveal.js does not try to load a discount document.