### PR TITLE
mark last used theme in menu

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -478,6 +478,12 @@ void MainWindow::lastUsedTheme()
     currentTheme = themeCollection->theme(themeName);
     applyCurrentTheme();
 
+    auto actionIter = std::find_if(
+          stylesGroup->actions().begin(), stylesGroup->actions().end(),
+          [&] (const QAction* action) -> bool { return action->text() == themeName; });
+    Q_ASSERT(actionIter != stylesGroup->actions().end());
+    (*actionIter)->setChecked(true);
+
     styleLabel->setText(themeName);
 }
 


### PR DESCRIPTION
after app restart there was no 'check' mark at currently used theme. I fixed it. see attached screenshots

**NO fix**
<img width="601" alt="screen shot 2016-01-30 at 11 17 00 am" src="https://cloud.githubusercontent.com/assets/947647/12694718/224630f2-c748-11e5-859d-7debc7e389b1.png">

**WITH fix**
<img width="569" alt="screen shot 2016-01-30 at 11 31 18 am" src="https://cloud.githubusercontent.com/assets/947647/12694737/569e9d76-c748-11e5-95b9-040179c55e15.png">
