### PR TITLE
cleanup project files

### DIFF
--- a/3rdparty/peg-markdown-highlight/peg-markdown-highlight.pro
+++ b/3rdparty/peg-markdown-highlight/peg-markdown-highlight.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT -= core gui
+CONFIG -= qt
 
 TARGET = pmh
 TEMPLATE = lib

--- a/app-static/app-static.pro
+++ b/app-static/app-static.pro
@@ -8,7 +8,7 @@ QT += gui webkitwidgets
 
 TARGET = app-static
 TEMPLATE = lib
-CONFIG += staticlib 
+CONFIG += staticlib
 CONFIG += c++11
 
 INCLUDEPATH += $$PWD
@@ -77,10 +77,7 @@ HEADERS += \
 #
 # Add search paths below /usr/local for Mac OSX
 #
-macx {
-  LIBS += -L/usr/local/lib
-  INCLUDEPATH += /usr/local/include
-}
+macx:INCLUDEPATH += /usr/local/include
 
 #
 # JSON configuration library
@@ -90,14 +87,7 @@ INCLUDEPATH += $$PWD/../libs/jsonconfig
 #
 # Discount library
 #
-win32-g++:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/discount/release/ -ldiscount
-else:win32-g++:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/discount/debug/ -ldiscount
-else:win32-msvc*:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/discount/release/ -llibdiscount
-else:win32-msvc*:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/discount/debug/ -llibdiscount
-else:unix: LIBS += -L/usr/lib -lmarkdown
-
 win32:INCLUDEPATH += $$PWD/../3rdparty/discount
-win32:DEPENDPATH += $$PWD/../3rdparty/discount
 
 #
 # Hoedown library
@@ -109,12 +99,5 @@ with_hoedown {
     SOURCES += converter/hoedownmarkdownconverter.cpp
     HEADERS += converter/hoedownmarkdownconverter.h
 
-    win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/hoedown/release/ -lhoedown
-    else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../3rdparty/hoedown/debug/ -lhoedown
-    else:unix: LIBS += -L/usr/lib -lhoedown
-
-    win32 {
-        INCLUDEPATH += $$PWD/../3rdparty/hoedown
-        DEPENDPATH += $$PWD/../3rdparty/hoedown
-    }
+    win32:INCLUDEPATH += $$PWD/../3rdparty/hoedown
 }

--- a/app/app.pro
+++ b/app/app.pro
@@ -14,7 +14,7 @@ TARGET = cutemarked
 TEMPLATE = app
 CONFIG += c++11
 
-unix {
+unix:!macx {
   CONFIG += link_pkgconfig
 }
 
@@ -248,7 +248,7 @@ message("Using LIBS=$$LIBS")
 
 ## INSTALLATION
 
-unix {
+unix:!macx {
    isEmpty(PREFIX): PREFIX = /usr
    DATADIR = $${PREFIX}/share
 

--- a/libs/peg-markdown-highlight/peg-markdown-highlight.pro
+++ b/libs/peg-markdown-highlight/peg-markdown-highlight.pro
@@ -8,17 +8,17 @@ QT += core gui widgets
 
 TARGET = pmh-adapter
 TEMPLATE = lib
-CONFIG += staticlib 
+CONFIG += staticlib
 CONFIG += c++11
 
 SOURCES += \
     pmhmarkdownparser.cpp \
-    styleparser.cpp 
+    styleparser.cpp
 
 HEADERS  += \
     pmhmarkdownparser.h \
     styleparser.h \
-    definitions.h 
+    definitions.h
 
 ###################################################################################################
 ## DEPENDENCIES
@@ -27,16 +27,5 @@ HEADERS  += \
 #
 # peg-markdown-highlight
 #
-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../3rdparty/peg-markdown-highlight/release/ -lpmh
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../3rdparty/peg-markdown-highlight/debug/ -lpmh
-else:unix: LIBS += -L$$OUT_PWD/../../3rdparty/peg-markdown-highlight/ -lpmh
 
 INCLUDEPATH += $$PWD/../../3rdparty/peg-markdown-highlight
-DEPENDPATH += $$PWD/../../3rdparty/peg-markdown-highlight
-
-win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../3rdparty/peg-markdown-highlight/release/libpmh.a
-else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../3rdparty/peg-markdown-highlight/debug/libpmh.a
-else:win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../3rdparty/peg-markdown-highlight/release/pmh.lib
-else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../../3rdparty/peg-markdown-highlight/debug/pmh.lib
-else:unix: PRE_TARGETDEPS += $$OUT_PWD/../../3rdparty/peg-markdown-highlight/libpmh.a
-


### PR DESCRIPTION
removed LIBS variable from static libraries project files. It is not needed for static libraries, they are not linked.
disabled 'link_pkgconfig' for OS X