### PR TITLE
fixed app info string in about dialog to be fully translatable

### DIFF
--- a/app/aboutdialog.cpp
+++ b/app/aboutdialog.cpp
@@ -26,7 +26,10 @@ AboutDialog::AboutDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->messageLabel->setText(QString("<p><b><font size=\"5\">CuteMarkEd</font></b><br>Version %1</p>").arg(qApp->applicationVersion()));
+    const QString appInfo = QString(ui->messageLabel->text())
+            .arg(qApp->applicationDisplayName())
+            .arg(qApp->applicationVersion());
+    ui->messageLabel->setText(appInfo);
 
     const QString description = QString("<p>%1<br>%2</p><p>%3</p>")
             .arg(tr("Qt-based, free and open source markdown editor with live HTML preview"))

--- a/app/aboutdialog.ui
+++ b/app/aboutdialog.ui
@@ -32,7 +32,7 @@
      <item>
       <widget class="QLabel" name="messageLabel">
        <property name="text">
-        <string>&lt;p&gt;&lt;b&gt;&lt;font size=&quot;5&quot;&gt;Program Name&lt;/font&gt;&lt;/b&gt;&lt;br&gt;Version 0.1&lt;/p&gt;</string>
+        <string>&lt;p&gt;&lt;b&gt;&lt;font size=&quot;5&quot;&gt;%1&lt;/font&gt;&lt;/b&gt;&lt;br&gt;Version %2&lt;/p&gt;</string>
        </property>
        <property name="scaledContents">
         <bool>false</bool>


### PR DESCRIPTION
Translation will now work for app version information string in about dialog