### PR TITLE
remember paper size and orientation on PDF export dialog during session

### DIFF
--- a/app/exportpdfdialog.cpp
+++ b/app/exportpdfdialog.cpp
@@ -21,7 +21,7 @@
 #include <QFileInfo>
 #include <QPrinter>
 
-ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
+ExportPdfDialog::ExportPdfDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ExportPdfDialog)
 {
@@ -30,12 +30,6 @@ ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
     // change button text of standard Ok button
     QPushButton *okButton = ui->buttonBox->button(QDialogButtonBox::Ok);
     okButton->setText("Export PDF");
-
-    if (!fileName.isEmpty()) {
-        QFileInfo info(fileName);
-        QString exportFileName = info.absoluteFilePath().replace(info.suffix(), "pdf");
-        ui->exportToLineEdit->setText(exportFileName);
-    }
 
     // fill paper size combobox
     ui->paperSizeComboBox->addItem(tr("A4 (210 x 297 mm, 8.26 x 11.69 inches)"), QPrinter::A4);
@@ -46,9 +40,6 @@ ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
     ui->paperSizeComboBox->addItem(tr("A6 (105 x 148 mm)"), QPrinter::A6);
     ui->paperSizeComboBox->addItem(tr("B4 (250 x 353 mm)"), QPrinter::B4);
     ui->paperSizeComboBox->addItem(tr("B5 (176 x 250 mm, 6.93 x 9.84 inches)"), QPrinter::B5);
-
-    // initialize Ok button state
-    exportToTextChanged(fileName);
 }
 
 ExportPdfDialog::~ExportPdfDialog()
@@ -77,6 +68,18 @@ QPrinter *ExportPdfDialog::printer()
     p->setPaperSize(size);
 
     return p;
+}
+
+void ExportPdfDialog::setFileName(const QString &fileName)
+{
+    if (!fileName.isEmpty()) {
+        QFileInfo info(fileName);
+        QString exportFileName = info.absoluteFilePath().replace(info.suffix(), "pdf");
+        ui->exportToLineEdit->setText(exportFileName);
+    }
+
+    // initialize Ok button state
+    exportToTextChanged(fileName);
 }
 
 void ExportPdfDialog::exportToTextChanged(const QString &text)

--- a/app/exportpdfdialog.h
+++ b/app/exportpdfdialog.h
@@ -29,10 +29,12 @@ class ExportPdfDialog : public QDialog
     Q_OBJECT
     
 public:
-    explicit ExportPdfDialog(const QString &fileName, QWidget *parent = 0);
+    explicit ExportPdfDialog(QWidget *parent = 0);
     ~ExportPdfDialog();
     
     QPrinter *printer();
+
+    void setFileName(const QString &fileName);
 
 private slots:
     void exportToTextChanged(const QString &text);

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -314,20 +314,20 @@ void MainWindow::fileExportToHtml()
 
 void MainWindow::fileExportToPdf()
 {
-	// using temporary QTextDocument instance to get links exported\printed correctly,
-	// as links will dissappear when printing directly from QWebView in current Qt implementation
-	// of QWebView::print() method (possible bug in Qt?)
-	// more info here: http://stackoverflow.com/questions/11629093/add-working-url-into-pdf-using-qt-qprinter
+    // using temporary QTextDocument instance to get links exported\printed correctly,
+    // as links will dissappear when printing directly from QWebView in current Qt implementation
+    // of QWebView::print() method (possible bug in Qt?)
+    // more info here: http://stackoverflow.com/questions/11629093/add-working-url-into-pdf-using-qt-qprinter
 
     if (!exportPdfDialog) // init, if not exists
         exportPdfDialog = new ExportPdfDialog(this);
 
     exportPdfDialog->setFileName(fileName);
     if (exportPdfDialog->exec() == QDialog::Accepted) {
-		 QTextDocument doc;
-		 doc.setHtml(ui->webView->page()->currentFrame()->toHtml());
-         doc.print(exportPdfDialog->printer());
-	}
+        QTextDocument doc;
+        doc.setHtml(ui->webView->page()->currentFrame()->toHtml());
+        doc.print(exportPdfDialog->printer());
+    }
 }
 
 void MainWindow::filePrint()

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -85,7 +85,8 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent) :
     htmlPreviewController(0),
     themeCollection(new ThemeCollection()),
     splitFactor(0.5),
-    rightViewCollapsed(false)
+    rightViewCollapsed(false),
+    exportPdfDialog(0)
 {
     ui->setupUi(this);
     setupUi();
@@ -318,11 +319,14 @@ void MainWindow::fileExportToPdf()
 	// of QWebView::print() method (possible bug in Qt?)
 	// more info here: http://stackoverflow.com/questions/11629093/add-working-url-into-pdf-using-qt-qprinter
 
-	ExportPdfDialog dialog(fileName);
-	if (dialog.exec() == QDialog::Accepted) {
+    if (!exportPdfDialog) // init, if not exists
+        exportPdfDialog = new ExportPdfDialog(this);
+
+    exportPdfDialog->setFileName(fileName);
+    if (exportPdfDialog->exec() == QDialog::Accepted) {
 		 QTextDocument doc;
 		 doc.setHtml(ui->webView->page()->currentFrame()->toHtml());
-		 doc.print(dialog.printer());
+         doc.print(exportPdfDialog->printer());
 	}
 }
 

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -40,6 +40,7 @@ class SlideLineMapping;
 class SnippetCollection;
 class ThemeCollection;
 class ViewSynchronizer;
+class ExportPdfDialog;
 
 
 class MainWindow : public QMainWindow
@@ -166,6 +167,8 @@ private:
     QString fileName;
     float splitFactor;
     bool rightViewCollapsed;
+
+    ExportPdfDialog *exportPdfDialog;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
During working session (from starting application and closing it down) every time call to "Export to PDF" will show dialog window with changes done last time it was executed (orientation and paper size will be the same as in previous execution).