### PR TITLE
fixed build on OS X

### DIFF
--- a/app/markdowneditor.cpp
+++ b/app/markdowneditor.cpp
@@ -524,13 +524,13 @@ void MarkdownEditor::drawRuler(QPaintEvent *e)
 
     // calculate vertical offset corresponding given
     // column margin in font metrics
-    int verticalOffset = round(QFontMetricsF(font).averageCharWidth() * rulerPos)
+    int verticalOffset = qRound(QFontMetricsF(font).averageCharWidth() * rulerPos)
             + contentOffset().x()
             + document()->documentMargin();
 
     // draw a ruler with color invert to background color (better readability)
     // and with 50% opacity
-    QPainter p(viewport()); 
+    QPainter p(viewport());
     p.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
     p.setPen(QColor(0xff, 0xff, 0xff));
     p.setOpacity(0.5);
@@ -589,7 +589,7 @@ QStringList MarkdownEditor::filterWordList(const QStringList &words, UnaryPredic
     foreach (const QString &word, words) {
         if (predicate(word))
         {
-           filteredWordList << word; 
+           filteredWordList << word;
         }
     }
 


### PR DESCRIPTION
fixed build error on OS X:
```
markdowneditor.cpp:527:26: error: use of undeclared identifier 'round'
    int verticalOffset = round(QFontMetricsF(font).averageCharWidth() * ...
                         ^
1 error generated.
```
there are was 2 solution for me:
1: add `#include <cmath>` , but I don't like it, because function return `float` or `double` value, then result will be cast to `int`
2: replace `round()` with `qRound()` , in returns `int` , no additional header required (already included with almost every Qt header)

used option 2, this is better solution for me

also deleted extra spaces at the end of some lines in edited file :) (my QtCreator configured to do it automatically on save)