### PR TITLE
Feature option to insert spaces instead of tabs 

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -138,6 +138,7 @@ void MainWindow::initializeApp()
     lastUsedTheme();
 
     ui->plainTextEdit->tabWidthChanged(options->tabWidth());
+    ui->plainTextEdit->spacesForTabsChanged(options->isSpacesForTabsEnabled());
     ui->plainTextEdit->rulerEnabledChanged(options->isRulerEnabled());
     ui->plainTextEdit->rulerPosChanged(options->rulerPos());
 
@@ -1055,6 +1056,8 @@ void MainWindow::setupMarkdownEditor()
             ui->plainTextEdit, &MarkdownEditor::editorFontChanged);
     connect(options, &Options::tabWidthChanged,
             ui->plainTextEdit, &MarkdownEditor::tabWidthChanged);
+    connect(options, &Options::spacesForTabsChanged,
+            ui->plainTextEdit, &MarkdownEditor::spacesForTabsChanged);
     connect(options, &Options::rulerEnabledChanged,
             ui->plainTextEdit, &MarkdownEditor::rulerEnabledChanged);
     connect(options, &Options::rulerPosChanged,

--- a/app/markdowneditor.cpp
+++ b/app/markdowneditor.cpp
@@ -257,6 +257,11 @@ void MarkdownEditor::tabWidthChanged(int tabWidth)
     setTabStopWidth(tabWidth*fm.width(' '));
 }
 
+void MarkdownEditor::spacesForTabsChanged(bool enabled)
+{
+    insertSpacesForTabs = enabled;
+}
+
 void MarkdownEditor::rulerEnabledChanged(bool enabled)
 {
     rulerEnabled = enabled;

--- a/app/markdowneditor.cpp
+++ b/app/markdowneditor.cpp
@@ -189,6 +189,31 @@ void MarkdownEditor::resizeEvent(QResizeEvent *event)
 
 void MarkdownEditor::keyPressEvent(QKeyEvent *e)
 {
+    if(insertSpacesForTabs)
+    {
+        if(Qt::Key_Tab == e->key())
+        {
+            QTextCursor cursor = textCursor();
+            QFontMetrics fm(font());
+            int tabwidth = this->tabStopWidth() / fm.width(' ');
+
+            cursor.beginEditBlock();
+            int currentPosition = cursor.position();
+            cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+            int indentToAdd = cursor.selectedText().length() % tabwidth;
+            indentToAdd = (0 == indentToAdd) ? tabwidth : tabwidth - indentToAdd;
+            cursor.setPosition(currentPosition);
+            for(int i = 0; i < indentToAdd; ++i)
+            {
+                cursor.insertText(" ");
+            }
+            cursor.endEditBlock();
+
+            e->accept();
+            return;
+        }
+    }
+
     if (completer && completer->isPopupVisible()) {
         // The following keys are forwarded by the completer to the widget
        switch (e->key()) {

--- a/app/markdowneditor.h
+++ b/app/markdowneditor.h
@@ -63,6 +63,7 @@ protected:
 
 public slots:
     void tabWidthChanged(int tabWidth);
+    void spacesForTabsChanged(bool enabled);
     void editorFontChanged(const QFont &font);
     void rulerEnabledChanged(bool enabled);
     void rulerPosChanged(int pos);
@@ -95,6 +96,7 @@ private:
     bool showHardLinebreaks;
     bool rulerEnabled;
     int rulerPos;
+    bool insertSpacesForTabs;
 };
 
 #endif // MARKDOWNEDITOR_H

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -26,6 +26,7 @@ static const char* FONT_FAMILY_DEFAULT = "Monospace";
 static const char* FONT_FAMILY = "editor/font/family";
 static const char* FONT_SIZE = "editor/font/size";
 static const char* TAB_WIDTH = "editor/tabwidth";
+static const char* SPACESFORTABS_ENABLED = "editor/spacesfortabs/enabled";
 static const char* LINECOLUMN_ENABLED = "editor/linecolumn/enabled";
 static const char* RULER_ENABLED = "editor/ruler/enabled";
 static const char* RULER_POS = "editor/ruler/pos";
@@ -80,6 +81,7 @@ Options::Options(QObject *parent) :
     m_sourceAtSingleSizeEnabled(true),
     m_spellingCheckEnabled(true),
     m_diagramSupportEnabled(false),
+    m_spacesForTabsEnabled(false),
     m_lineColumnEnabled(true),
     m_rulerEnabled(false),
     m_rulerPos(80),
@@ -125,6 +127,17 @@ void Options::setTabWidth(int width)
 {
     m_tabWidth = width;
     emit tabWidthChanged(width);
+}
+
+bool Options::isSpacesForTabsEnabled() const
+{
+    return m_spacesForTabsEnabled;
+}
+
+void Options::setSpacesForTabsEnabled(bool enabled)
+{
+    m_spacesForTabsEnabled = enabled;
+    emit spacesForTabsChanged(enabled);
 }
 
 bool Options::isLineColumnEnabled() const
@@ -493,6 +506,7 @@ void Options::readSettings()
     int fontSize = settings.value(FONT_SIZE, 10).toInt();
 
     m_tabWidth = settings.value(TAB_WIDTH, 8).toInt();
+    m_spacesForTabsEnabled = settings.value(SPACESFORTABS_ENABLED, false).toBool();
     m_lineColumnEnabled = settings.value(LINECOLUMN_ENABLED, false).toBool();
     m_rulerEnabled = settings.value(RULER_ENABLED, false).toBool();
     m_rulerPos = settings.value(RULER_POS, 80).toInt();
@@ -567,6 +581,7 @@ void Options::writeSettings()
     settings.setValue(FONT_FAMILY, font.family());
     settings.setValue(FONT_SIZE, font.pointSize());
     settings.setValue(TAB_WIDTH, m_tabWidth);
+    settings.setValue(SPACESFORTABS_ENABLED, m_spacesForTabsEnabled);
     settings.setValue(LINECOLUMN_ENABLED, m_lineColumnEnabled);
     settings.setValue(RULER_ENABLED, m_rulerEnabled);
     settings.setValue(RULER_POS, m_rulerPos);

--- a/app/options.h
+++ b/app/options.h
@@ -45,6 +45,9 @@ public:
     int tabWidth() const;
     void setTabWidth(int width);
 
+    bool isSpacesForTabsEnabled() const;
+    void setSpacesForTabsEnabled(bool enabled);
+
     bool isLineColumnEnabled() const;
     void setLineColumnEnabled(bool enabled);
 
@@ -159,6 +162,7 @@ signals:
     void editorFontChanged(const QFont &font);
     void editorStyleChanged();
     void tabWidthChanged(int tabWidth);
+    void spacesForTabsChanged(bool enabled);
     void lineColumnEnabledChanged(bool enabled);
     void rulerEnabledChanged(bool enabled);
     void rulerPosChanged(int pos);
@@ -193,6 +197,7 @@ private:
     bool m_spellingCheckEnabled;
     bool m_yamlHeaderSupportEnabled;
     bool m_diagramSupportEnabled;
+    bool m_spacesForTabsEnabled;
     bool m_lineColumnEnabled;
     bool m_rulerEnabled;
     int m_rulerPos;

--- a/app/optionsdialog.cpp
+++ b/app/optionsdialog.cpp
@@ -287,6 +287,7 @@ void OptionsDialog::readState()
     ui->sizeComboBox->setCurrentText(QString().setNum(font.pointSize()));
     ui->sourceSingleSizedCheckBox->setChecked(options->isSourceAtSingleSizeEnabled());
     ui->tabWidthSpinBox->setValue(options->tabWidth());
+    ui->spacesForTabsCheckBox->setChecked(options->isSpacesForTabsEnabled());
     ui->lineColumnCheckBox->setChecked(options->isLineColumnEnabled());
     ui->rulerEnableCheckBox->setChecked(options->isRulerEnabled());
     ui->rulerPosSpinBox->setValue(options->rulerPos());
@@ -337,6 +338,7 @@ void OptionsDialog::saveState()
     options->setEditorFont(font);
     options->setSourceAtSingleSizeEnabled(ui->sourceSingleSizedCheckBox->isChecked());
     options->setTabWidth(ui->tabWidthSpinBox->value());
+    options->setSpacesForTabsEnabled(ui->spacesForTabsCheckBox->isChecked());
     options->setLineColumnEnabled(ui->lineColumnCheckBox->isChecked());
     options->setRulerEnabled(ui->rulerEnableCheckBox->isChecked());
     options->setRulerPos(ui->rulerPosSpinBox->value());

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -194,6 +194,29 @@
            </widget>
           </item>
           <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>6</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="spacesForTabsCheckBox">
+            <property name="text">
+             <string>Insert Spacesfor Tabs</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/app/optionsdialog.ui
+++ b/app/optionsdialog.ui
@@ -212,7 +212,7 @@
           <item>
            <widget class="QCheckBox" name="spacesForTabsCheckBox">
             <property name="text">
-             <string>Insert Spacesfor Tabs</string>
+             <string>Insert Spaces for Tabs</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
I would like to add an "Insert Spaces for Tabs" option to the editor.