### PR TITLE
Feature/filechangewatcher

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1000,8 +1000,8 @@ void MainWindow::setupActions()
             generator, SLOT(setCodeHighlightingEnabled(bool)));
     connect(ui->menuLanguages, SIGNAL(languageTriggered(Dictionary)),
             this, SLOT(languageChanged(Dictionary)));
-    connect(&fileSystemWatcher, SIGNAL(fileChanged(const QString)),
-            this, SLOT(fileExternallyChanged(const QString)));
+    connect(&fileSystemWatcher, &QFileSystemWatcher::fileChanged,
+            this, &MainWindow::fileExternallyChanged);
 
     // help menu
     ui->actionMarkdownSyntax->setShortcut(QKeySequence::HelpContents);

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -20,6 +20,7 @@
 #include <QMainWindow>
 #include <QMap>
 #include <QHash>
+#include <QFileSystemWatcher>
 #include <themes/theme.h>
 
 namespace Ui {
@@ -59,6 +60,7 @@ private slots:
     void initializeApp();
     void openRecentFile(const QString &fileName);
     void languageChanged(const Dictionary &dictionary);
+    void fileExternallyChanged(const QString &path);
 
     void fileNew();
     void fileOpen();
@@ -164,6 +166,7 @@ private:
     QString fileName;
     float splitFactor;
     bool rightViewCollapsed;
+    QFileSystemWatcher fileSystemWatcher;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This pull request adds the feature to watch for external changes at the currently opened document.

If the document is changed externally, the user is ask whether to reload from the file or to keep the current buffer.