### PR TITLE
312 revert exportpdf to get back images and formulas

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -312,16 +312,9 @@ void MainWindow::fileExportToHtml()
 
 void MainWindow::fileExportToPdf()
 {
-	// using temporary QTextDocument instance to get links exported\printed correctly,
-	// as links will dissappear when printing directly from QWebView in current Qt implementation
-	// of QWebView::print() method (possible bug in Qt?)
-	// more info here: http://stackoverflow.com/questions/11629093/add-working-url-into-pdf-using-qt-qprinter
-
 	ExportPdfDialog dialog(fileName);
 	if (dialog.exec() == QDialog::Accepted) {
-		 QTextDocument doc;
-		 doc.setHtml(ui->webView->page()->currentFrame()->toHtml());
-		 doc.print(dialog.printer());
+		ui->webView->print(dialog.printer());
 	}
 }
 


### PR DESCRIPTION
Supersedes #315
revert export to PDF logic to get back Math formulas and images (reverts back to "missing links" state)