### PR TITLE
Fix export filename (fixes #319)

### DIFF
--- a/app/exporthtmldialog.cpp
+++ b/app/exporthtmldialog.cpp
@@ -19,6 +19,7 @@
 
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QDir>
 
 ExportHtmlDialog::ExportHtmlDialog(const QString &fileName, QWidget *parent) :
     QDialog(parent),
@@ -34,7 +35,7 @@ ExportHtmlDialog::ExportHtmlDialog(const QString &fileName, QWidget *parent) :
         QFileInfo info(fileName);
         QString absFilePath = info.absoluteFilePath();
         QString exportFileName = absFilePath.mid(0, absFilePath.lastIndexOf('.')) + ".html";
-        ui->exportToLineEdit->setText(exportFileName);
+        ui->exportToLineEdit->setText(QDir::toNativeSeparators(exportFileName));
     }
 
     // initialize Ok button state
@@ -48,7 +49,7 @@ ExportHtmlDialog::~ExportHtmlDialog()
 
 QString ExportHtmlDialog::fileName() const
 {
-    return ui->exportToLineEdit->text();
+    return QDir::fromNativeSeparators(ui->exportToLineEdit->text());
 }
 
 bool ExportHtmlDialog::includeCSS() const
@@ -70,11 +71,11 @@ void ExportHtmlDialog::exportToTextChanged(const QString &text)
 
 void ExportHtmlDialog::chooseFileButtonClicked()
 {
-    QString fileName = ui->exportToLineEdit->text();
+    QString fileName = QDir::fromNativeSeparators(ui->exportToLineEdit->text());
 
     fileName = QFileDialog::getSaveFileName(this, tr("Export to HTML..."), fileName,
                                                   tr("HTML Files (*.html *.htm);;All Files (*)"));
     if (!fileName.isEmpty()) {
-        ui->exportToLineEdit->setText(fileName);
+        ui->exportToLineEdit->setText(QDir::toNativeSeparators(fileName));
     }
 }

--- a/app/exporthtmldialog.cpp
+++ b/app/exporthtmldialog.cpp
@@ -32,7 +32,8 @@ ExportHtmlDialog::ExportHtmlDialog(const QString &fileName, QWidget *parent) :
 
     if (!fileName.isEmpty()) {
         QFileInfo info(fileName);
-        QString exportFileName = info.absoluteFilePath().replace(info.suffix(), "html");
+        QString absFilePath = info.absoluteFilePath();
+        QString exportFileName = absFilePath.mid(0, absFilePath.lastIndexOf('.')) + ".html";
         ui->exportToLineEdit->setText(exportFileName);
     }
 

--- a/app/exportpdfdialog.cpp
+++ b/app/exportpdfdialog.cpp
@@ -20,6 +20,7 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QPrinter>
+#include <QDir>
 
 ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
     QDialog(parent),
@@ -35,7 +36,7 @@ ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
         QFileInfo info(fileName);
         QString absFilePath = info.absoluteFilePath();
         QString exportFileName = absFilePath.mid(0, absFilePath.lastIndexOf('.')) + ".pdf";
-        ui->exportToLineEdit->setText(exportFileName);
+        ui->exportToLineEdit->setText(QDir::toNativeSeparators(exportFileName));
     }
 
     // fill paper size combobox
@@ -59,7 +60,7 @@ ExportPdfDialog::~ExportPdfDialog()
 
 QPrinter *ExportPdfDialog::printer()
 {
-    QString fileName = ui->exportToLineEdit->text();
+    QString fileName = QDir::fromNativeSeparators(ui->exportToLineEdit->text());
 
     QPrinter::Orientation orientation;
     if (ui->portraitRadioButton->isChecked()) {
@@ -89,11 +90,11 @@ void ExportPdfDialog::exportToTextChanged(const QString &text)
 
 void ExportPdfDialog::chooseFileButtonClicked()
 {
-    QString fileName = ui->exportToLineEdit->text();
+    QString fileName = QDir::fromNativeSeparators(ui->exportToLineEdit->text());
 
     fileName = QFileDialog::getSaveFileName(this, tr("Export to PDF..."), fileName,
                                                   tr("PDF Files (*.pdf);;All Files (*)"));
     if (!fileName.isEmpty()) {
-        ui->exportToLineEdit->setText(fileName);
+        ui->exportToLineEdit->setText(QDir::toNativeSeparators(fileName));
     }
 }

--- a/app/exportpdfdialog.cpp
+++ b/app/exportpdfdialog.cpp
@@ -33,7 +33,8 @@ ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
 
     if (!fileName.isEmpty()) {
         QFileInfo info(fileName);
-        QString exportFileName = info.absoluteFilePath().replace(info.suffix(), "pdf");
+        QString absFilePath = info.absoluteFilePath();
+        QString exportFileName = absFilePath.mid(0, absFilePath.lastIndexOf('.')) + ".pdf";
         ui->exportToLineEdit->setText(exportFileName);
     }
 


### PR DESCRIPTION
1. changed way in what exported filename was generated (fixes https://github.com/cloose/CuteMarkEd/issues/319)
2. used OS native path separators ("\" in Windows, "/" in Linux and OS X) to display exported path (cosmetic change)

note filename in window header and in export dialog

before fix:
<img width="1440" alt="screenshot 2016-08-18 04 12 18" src="https://cloud.githubusercontent.com/assets/947647/17759636/9b5fb6aa-6501-11e6-8a46-b5d182fd4f26.png">

after fix:
<img width="1440" alt="screenshot 2016-08-18 04 13 09" src="https://cloud.githubusercontent.com/assets/947647/17759635/9b5d9b18-6501-11e6-8bfc-2e1d78a24fa4.png">
