### PR TITLE
-2 warnings about unused variables

### DIFF
--- a/app-static/completionlistmodel.cpp
+++ b/app-static/completionlistmodel.cpp
@@ -27,6 +27,7 @@ CompletionListModel::CompletionListModel(QObject *parent) :
 
 int CompletionListModel::rowCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent);
     return snippets.count() + words.count();
 }
 

--- a/app/controls/fileexplorerwidget.cpp
+++ b/app/controls/fileexplorerwidget.cpp
@@ -56,6 +56,7 @@ void FileExplorerWidget::showEvent(QShowEvent *event)
         model->setRootPath("");
         initialized = true;
     }
+    QWidget::showEvent(event);
 }
 
 void FileExplorerWidget::fileOpen(const QModelIndex &index)


### PR DESCRIPTION
fixed to compiler warning about unused parameters: one marked as unused using Qt macro, another passed to same method in parent class