### PR TITLE
remember paper size and orientation for pdf export between sessions

### DIFF
--- a/app/exportpdfdialog.cpp
+++ b/app/exportpdfdialog.cpp
@@ -21,9 +21,12 @@
 #include <QFileInfo>
 #include <QPrinter>
 
-ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
+#include "options.h"
+
+ExportPdfDialog::ExportPdfDialog(const QString &fileName, Options *opt, QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::ExportPdfDialog)
+    ui(new Ui::ExportPdfDialog),
+    options(opt)
 {
     ui->setupUi(this);
 
@@ -47,12 +50,16 @@ ExportPdfDialog::ExportPdfDialog(const QString &fileName, QWidget *parent) :
     ui->paperSizeComboBox->addItem(tr("B4 (250 x 353 mm)"), QPrinter::B4);
     ui->paperSizeComboBox->addItem(tr("B5 (176 x 250 mm, 6.93 x 9.84 inches)"), QPrinter::B5);
 
+    // restore GUI state
+    loadState();
+
     // initialize Ok button state
     exportToTextChanged(fileName);
 }
 
 ExportPdfDialog::~ExportPdfDialog()
 {
+    saveState();
     delete ui;
 }
 
@@ -95,4 +102,29 @@ void ExportPdfDialog::chooseFileButtonClicked()
     if (!fileName.isEmpty()) {
         ui->exportToLineEdit->setText(fileName);
     }
+}
+
+void ExportPdfDialog::loadState()
+{
+    if(options->pdfOrientation() == QPrinter::Portrait)
+        ui->portraitRadioButton->setChecked(true);
+    else
+        ui->landscapeRadioButton->setChecked(true);
+
+    int idx = ui->paperSizeComboBox->findData(options->pdfPageSize());
+    if(idx>=0)
+        ui->paperSizeComboBox->setCurrentIndex(idx);
+}
+
+void ExportPdfDialog::saveState()
+{
+    // save settings
+    if(ui->portraitRadioButton->isChecked())
+        options->setPdfOrientation(QPrinter::Portrait);
+    else
+        options->setPdfOrientation(QPrinter::Landscape);
+
+    QVariant v = ui->paperSizeComboBox->itemData(ui->paperSizeComboBox->currentIndex());
+    QPrinter::PaperSize size = (QPrinter::PaperSize)v.toInt();
+    options->setPdfPageSize(size);
 }

--- a/app/exportpdfdialog.h
+++ b/app/exportpdfdialog.h
@@ -23,13 +23,14 @@ namespace Ui {
 class ExportPdfDialog;
 }
 class QPrinter;
+class Options;
 
 class ExportPdfDialog : public QDialog
 {
     Q_OBJECT
     
 public:
-    explicit ExportPdfDialog(const QString &fileName, QWidget *parent = 0);
+    explicit ExportPdfDialog(const QString &fileName, Options *opt, QWidget *parent = 0);
     ~ExportPdfDialog();
     
     QPrinter *printer();
@@ -39,7 +40,13 @@ private slots:
     void chooseFileButtonClicked();
 
 private:
+    void loadState();
+    void saveState();
+
+private:
     Ui::ExportPdfDialog *ui;
+
+    Options *options;
 };
 
 #endif // EXPORTPDFDIALOG_H

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -325,7 +325,7 @@ void MainWindow::fileExportToPdf()
     // of QWebView::print() method (possible bug in Qt?)
     // more info here: http://stackoverflow.com/questions/11629093/add-working-url-into-pdf-using-qt-qprinter
 
-    ExportPdfDialog dialog(fileName);
+    ExportPdfDialog dialog(fileName, options);
     if (dialog.exec() == QDialog::Accepted) {
          QTextDocument doc;
          doc.setHtml(ui->webView->page()->currentFrame()->toHtml());

--- a/app/options.cpp
+++ b/app/options.cpp
@@ -57,6 +57,8 @@ static const char* SPELLINGCHECK_ENABLED = "spelling/enabled";
 static const char* DICTIONARY_LANGUAGE = "spelling/language";
 static const char* YAMLHEADERSUPPORT_ENABLED = "yamlheadersupport/enabled";
 static const char* DIAGRAMSUPPORT_ENABLED = "diagramsupport/enabled";
+static const char* PDF_ORIENTATION = "pdf/orientation";
+static const char* PDF_PAGE_SIZE = "pdf/pagesize";
 
 static const char* DEPRECATED__LAST_USED_STYLE = "general/lastusedstyle";
 
@@ -84,7 +86,9 @@ Options::Options(QObject *parent) :
     m_rulerEnabled(false),
     m_rulerPos(80),
     m_markdownConverter(DiscountMarkdownConverter),
-    m_lastUsedTheme(THEME_DEFAULT)
+    m_lastUsedTheme(THEME_DEFAULT),
+    m_PdfOrientation(QPrinter::Portrait),
+    m_PdfPageSize(QPrinter::A4)
 {
 }
 
@@ -480,6 +484,26 @@ void Options::setLastUsedTheme(const QString &theme)
     m_lastUsedTheme = theme;
 }
 
+QPrinter::Orientation Options::pdfOrientation() const
+{
+    return m_PdfOrientation;
+}
+
+void Options::setPdfOrientation(const QPrinter::Orientation orientation)
+{
+    m_PdfOrientation = orientation;
+}
+
+QPrinter::PageSize Options::pdfPageSize() const
+{
+    return m_PdfPageSize;
+}
+
+void Options::setPdfPageSize(const QPrinter::PageSize pageSize)
+{
+    m_PdfPageSize = pageSize;
+}
+
 void Options::readSettings()
 {
     QSettings settings;
@@ -546,6 +570,10 @@ void Options::readSettings()
     // spelling check settings
     m_spellingCheckEnabled = settings.value(SPELLINGCHECK_ENABLED, true).toBool();
     m_dictionaryLanguage = settings.value(DICTIONARY_LANGUAGE, "en_US").toString();
+
+    // pdf export settings
+    m_PdfOrientation = (QPrinter::Orientation)settings.value(PDF_ORIENTATION, 0).toInt();
+    m_PdfPageSize = (QPrinter::PageSize)settings.value(PDF_PAGE_SIZE, 0).toInt();
 
     // migrate deprecated lastUsedStyle option
     if (settings.contains(DEPRECATED__LAST_USED_STYLE)) {
@@ -616,6 +644,10 @@ void Options::writeSettings()
     // spelling check settings
     settings.setValue(SPELLINGCHECK_ENABLED, m_spellingCheckEnabled);
     settings.setValue(DICTIONARY_LANGUAGE, m_dictionaryLanguage);
+
+    // pdf export settings
+    settings.setValue(PDF_ORIENTATION, m_PdfOrientation);
+    settings.setValue(PDF_PAGE_SIZE, m_PdfPageSize);
 }
 
 void Options::migrateLastUsedStyleOption(QSettings &settings)

--- a/app/options.h
+++ b/app/options.h
@@ -22,6 +22,7 @@
 #include <QKeySequence>
 #include <QMap>
 #include <QSettings>
+#include <QPrinter>
 
 class Options : public QObject
 {
@@ -152,6 +153,13 @@ public:
     QString lastUsedTheme() const;
     void setLastUsedTheme(const QString &theme);
 
+    /* Export to PDF options */
+    QPrinter::Orientation pdfOrientation() const;
+    void setPdfOrientation(const QPrinter::Orientation orientation);
+
+    QPrinter::PageSize pdfPageSize() const;
+    void setPdfPageSize(const QPrinter::PageSize pageSize);
+
     void readSettings();
     void writeSettings();
 
@@ -206,6 +214,8 @@ private:
     int m_defaultFontSize;
     int m_defaultFixedFontSize;
     QMap<QString, QKeySequence> m_customShortcuts;
+    QPrinter::Orientation m_PdfOrientation;
+    QPrinter::PageSize m_PdfPageSize;
 };
 
 #endif // OPTIONS_H


### PR DESCRIPTION
Remember user selected paper size and orientation for pdf export dialog between sessions (defaults to A4 and Portrait orientation).