### PR TITLE
styles: use explicit bgcolor

### DIFF
--- a/app/styles/markdown.css
+++ b/app/styles/markdown.css
@@ -25,6 +25,7 @@ body{
     line-height: 1;
     max-width: 960px;
     padding: 30px;
+    background-color: #ffffff;
 }
 h1, h2, h3, h4 {
     color: #111111;


### PR DESCRIPTION
If the background color isn't explicitly set in the CSS, then the text is unreadable on systems with dark widget styles.