### PR TITLE
Fix possible crash depending platforms

### DIFF
--- a/app-static/app-static.pro
+++ b/app-static/app-static.pro
@@ -5,6 +5,7 @@
 #
 
 QT += gui webkitwidgets
+QT += gui-private
 
 TARGET = app-static
 TEMPLATE = lib

--- a/app-static/themes/themecollection.cpp
+++ b/app-static/themes/themecollection.cpp
@@ -19,6 +19,8 @@
 #include <jsonfile.h>
 #include <themes/jsonthemetranslatorfactory.h>
 
+#include <QtGui/qpa/qplatformtheme.h>
+
 bool ThemeCollection::load(const QString &fileName)
 {
     return JsonFile<Theme>::load(fileName, this);
@@ -43,12 +45,12 @@ const Theme &ThemeCollection::at(int offset) const
 
 bool ThemeCollection::contains(const QString &name) const
 {
-    return themesIndex.contains(name);
+    return themesIndex.contains(QPlatformTheme::removeMnemonics(name));
 }
 
 const Theme ThemeCollection::theme(const QString &name) const
 {
-    return at(themesIndex.indexOf(name));
+    return at(themesIndex.indexOf(QPlatformTheme::removeMnemonics(name)));
 }
 
 QStringList ThemeCollection::themeNames() const


### PR DESCRIPTION
Some platforms add mnemonics to actions label (for me KDE / Linux).
This then make the current code to break because of & added to the text.
This change fix the crash when switching themes.
This use the private gui headers.